### PR TITLE
Remove Zany80 from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ FC | Language | Price & License | Platform | Display
 [Voxatron](https://www.lexaloffle.com/voxatron.php) by Lexaloffle | [micro-scripting](https://www.lexaloffle.com/voxatron.php?page=resources) | [$19.99](https://www.lexaloffle.com/voxatron.php) | Windows, macOS, Linux | Voxel
 [VVpet](https://github.com/gardrek/VVpet) by Gardrek | Lua | Free, [?](https://github.com/gardrek/VVpet) | Löve | 64x64x2, 128x128x4, Configurable
 [yuki-js](https://github.com/nrkn/yuki-js) by Nik Coughlin | JavaScript (subset) | Free, [MIT](https://github.com/nrkn/yuki-js) | Browser | Configurable
-[Zany80](https://zany80.github.io) by Noam Preil | [Z80 ASM, C89](https://zany80.github.io/documentation/programming/) | [Free](https://zany80.github.io/downloads.html), [Apache](https://github.com/zany80) | Windows, Linux, [Browser](https://zany80.github.io/native/emscripten/) | Serial I/O
 
 * Ordered by: alphabet.
 * Language: Mean built-in language(s) for end users, not the language in which it was created.


### PR DESCRIPTION
I've abandoned Zany80, probably indefinitely; it's served its purpose as what was honestly more a research project than a console others could use.