### PR TITLE
Add Octo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ FC | Language | Price & License | Platform | Display
 [nano Jammer](https://morgan3d.github.io/nano/) by Casual Effects | [nano](https://morgan3d.github.io/nano/doc/specification.md.html) | [Free](https://morgan3d.github.io/nano/), [BSD](https://github.com/morgan3d/nano/) | Browser | 64x64
 [NEKO8](https://egordorichev.itch.io/neko8) by Egor Dorichev | Lua, BASIC, ASM, MoonScript | [NYOP](https://egordorichev.itch.io/neko8), [?](https://github.com/egordorichev/neko8) | Windows, macOS, Linux, Android | 192x128
 [Nibble](https://docs.nibble.world/) by Nibble Team | Lua | [Free](https://github.com/nibbleteam/nibble/releases), [GPLv3](https://github.com/nibbleteam/nibble/blob/master/LICENSE.md) | Windows, macOS, Linux | 400x240 24bit/7bit
+[Octo](http://octo-ide.com) by John Earnest | ASM | [Free](https://github.com/JohnEarnest/Octo), [MIT](https://github.com/JohnEarnest/Octo) | Browser | 128x64 2bit
 [Phosphor](https://mlepage.github.io/phosphor/) by Marc Lepage | Lua | [Free](https://mlepage.github.io/phosphor/), [MIT](https://github.com/mlepage/phosphor) | Browser | 192x128
 [PICO-8](https://www.lexaloffle.com/pico-8.php) by Lexaloffle | Lua | [$14.99](https://www.lexaloffle.com/pico-8.php) | Windows, macOS, Linux, Raspbery Pi | 128x128 4bit
 [Pix64](https://zappedcow.itch.io/pix64) by ZappedCow | PNG | [NYOP](https://zappedcow.itch.io/pix64) | Windows, Linux | 64x64


### PR DESCRIPTION
[Octo](https://github.com/JohnEarnest/Octo) is based on [CHIP-8](https://en.wikipedia.org/wiki/CHIP-8), the original fictional game console. It adds a complete toolkit for game development: a debugger, sprite editor, high-level assembler, and some other goodies. Additionally, Octo provides several ways of sharing programs, including an image-based cartridge format:

![Cartridge Example](https://raw.githubusercontent.com/JohnEarnest/Octo/gh-pages/images/murdercart.gif)

I think that the all-in-one nature of the environment and its constraints make it count as a "fantasy console"; it's very similar to PuzzleScript in this regard.

There's also a fairly sizable collection of CHIP-8 games developed with Octo in the [Chip-8 Archive](https://github.com/JohnEarnest/chip8Archive) gallery.